### PR TITLE
Fixed a bug in ARGV parsing for service.rb in chapter 1

### DIFF
--- a/chapter_01/service.rb
+++ b/chapter_01/service.rb
@@ -6,7 +6,7 @@ require 'sinatra'
 require "#{File.dirname(__FILE__)}/models/user"
 
 # setting up our environment
-env_arg = ARGV.index("-e")
+env_arg = ARGV[ARGV.index("-e") + 1]
 env = env_arg || ENV["SINATRA_ENV"] || "development"
 databases = YAML.load_file("config/database.yml")
 ActiveRecord::Base.establish_connection(databases[env])

--- a/chapter_01/spec/client_spec.rb
+++ b/chapter_01/spec/client_spec.rb
@@ -7,7 +7,7 @@ require File.dirname(__FILE__) + '/../client'
 # the database. We could change this by deleting all users in the test setup.
 describe "client" do
   before(:all) do
-    User.base_uri = "http://localhost:3000"
+    User.base_uri = "http://127.0.0.1:3000"
 
     User.destroy("paul")
     User.destroy("trotter")


### PR DESCRIPTION
ARGV.index("-e") returns a integer, not the value of the '-e' command line argument.

Also, 'localhost' was not pointing at the correct place on my machine, so I change the endpoint address to use the 127.0.0.1 IP address
