### PR TITLE
To get sample working in Ruby 1.9.2

### DIFF
--- a/chapter_10/public_private/config.ru
+++ b/chapter_10/public_private/config.ru
@@ -2,4 +2,4 @@ require 'rsa_sig_validator'
 
 use Rack::RsaSigValidator
 
-run Proc.new { |env| [200, {"Content-Type" => "text/html"}, "Hello World! From Rsa Signature\n"] }
+run Proc.new { |env| [200, {"Content-Type" => "text/html"}, ["Hello World! From Rsa Signature\n"]] }

--- a/chapter_10/public_private/rsa_sig_validator.rb
+++ b/chapter_10/public_private/rsa_sig_validator.rb
@@ -13,7 +13,7 @@ module Rack
       if signature_is_valid?(env)
         @app.call(env)
       else
-        [401, {"Content-Type" => "text/html"}, "Bad Signature"]
+        [401, {"Content-Type" => "text/html"}, ["Bad Signature"]]
       end
     end
 


### PR DESCRIPTION
The Rack application on Chapter 10 does not run on Ruby 1.9.2(rvm : ruby 1.9.3p0 (2011-10-30 revision 33570) [i686-linux] ). The error is "Response body must respond to each". Ruby 1.9 (unlike 1.8) apparently doesn't provide an each method on string objects.

A possible fix is to change the following rack responses from this: 
[200, {}, "output"] to this: 
[200, {}, ["output"]] 
thus making the body string into an array of strings for enumerating.
