### PR TITLE
changed view templates to reflect actual columns in database

### DIFF
--- a/chapter_03/social_feed_reader/app/views/users/edit.html.erb
+++ b/chapter_03/social_feed_reader/app/views/users/edit.html.erb
@@ -4,16 +4,16 @@
   <%= f.error_messages %>
 
   <p>
-    <%= f.label :string %><br />
-    <%= f.text_field :string %>
+    <%= f.label :name %><br />
+    <%= f.text_field :name %>
   </p>
   <p>
-    <%= f.label :string %><br />
-    <%= f.text_field :string %>
+    <%= f.label :bio  %><br />
+    <%= f.text_field :bio %>
   </p>
   <p>
-    <%= f.label :string %><br />
-    <%= f.text_field :string %>
+    <%= f.label :email %><br />
+    <%= f.text_field :email %>
   </p>
   <p>
     <%= f.submit 'Update' %>

--- a/chapter_03/social_feed_reader/app/views/users/index.html.erb
+++ b/chapter_03/social_feed_reader/app/views/users/index.html.erb
@@ -2,16 +2,16 @@
 
 <table>
   <tr>
-    <th>String</th>
-    <th>String</th>
-    <th>String</th>
+    <th>Name</th>
+    <th>Bio</th>
+    <th>Email</th>
   </tr>
 
 <% @users.each do |user| %>
   <tr>
-    <td><%=h user.string %></td>
-    <td><%=h user.string %></td>
-    <td><%=h user.string %></td>
+    <td><%=h user.name %></td>
+    <td><%=h user.bio %></td>
+    <td><%=h user.email %></td>
     <td><%= link_to 'Show', user %></td>
     <td><%= link_to 'Edit', edit_user_path(user) %></td>
     <td><%= link_to 'Destroy', user, :confirm => 'Are you sure?', :method => :delete %></td>

--- a/chapter_03/social_feed_reader/app/views/users/new.html.erb
+++ b/chapter_03/social_feed_reader/app/views/users/new.html.erb
@@ -4,16 +4,16 @@
   <%= f.error_messages %>
 
   <p>
-    <%= f.label :string %><br />
-    <%= f.text_field :string %>
+    <%= f.label :name %><br />
+    <%= f.text_field :name %>
   </p>
   <p>
-    <%= f.label :string %><br />
-    <%= f.text_field :string %>
+    <%= f.label :bio  %><br />
+    <%= f.text_field :bio %>
   </p>
   <p>
-    <%= f.label :string %><br />
-    <%= f.text_field :string %>
+    <%= f.label :email %><br />
+    <%= f.text_field :email %>
   </p>
   <p>
     <%= f.submit 'Create' %>

--- a/chapter_03/social_feed_reader/app/views/users/show.html.erb
+++ b/chapter_03/social_feed_reader/app/views/users/show.html.erb
@@ -1,16 +1,16 @@
 <p>
-  <b>String:</b>
-  <%=h @user.string %>
+  <b>Name:</b>
+  <%=h @user.name %>
 </p>
 
 <p>
-  <b>String:</b>
-  <%=h @user.string %>
+  <b>Bio:</b>
+  <%=h @user.bio %>
 </p>
 
 <p>
-  <b>String:</b>
-  <%=h @user.string %>
+  <b>Email:</b>
+  <%=h @user.email %>
 </p>
 
 


### PR DESCRIPTION
When running the rails server, the browser displays errors as 'string' is not an actual column on the User table. 

I'm assuming that 'string' is on there as just an example, but this way the browser can at least be fired up. 
