### PR TITLE
Fix assignment instead of comparison of password.

### DIFF
--- a/chapter_10/basic_auth/basic_auth.ru
+++ b/chapter_10/basic_auth/basic_auth.ru
@@ -4,6 +4,6 @@ use Rack::Auth::Basic, "Protected Realm" do |username, password|
   # You could make a request to a user service here to see if the user is correct
   # For apps that are not externally accessible, it's sometimes easier (though not quite as secure) 
   # to just have a standard username and pass:
-  username == "bobs_protection" && password = "bobs_sekret_pass"
+  username == "bobs_protection" && password == "bobs_sekret_pass"
 end
 run ProtectedApp.new


### PR DESCRIPTION
This is why some people prefer `"something" == variable` comparisons to prevent such a mistakes.
